### PR TITLE
Allow the test transaction to be accessed in tests

### DIFF
--- a/createEnvironment.js
+++ b/createEnvironment.js
@@ -48,6 +48,7 @@ function createEnvironment({ baseEnvironment } = {}) {
         name: this.testPath,
         tags: transactionOptions.tags,
       });
+      this.global._transaction = transaction;
 
       this.Sentry.configureScope((scope) => scope.setSpan(this.transaction));
 

--- a/createEnvironment.js
+++ b/createEnvironment.js
@@ -48,7 +48,7 @@ function createEnvironment({ baseEnvironment } = {}) {
         name: this.testPath,
         tags: transactionOptions.tags,
       });
-      this.global._transaction = transaction;
+      this.global._transaction = this.transaction;
 
       this.Sentry.configureScope((scope) => scope.setSpan(this.transaction));
 

--- a/createEnvironment.js
+++ b/createEnvironment.js
@@ -48,7 +48,7 @@ function createEnvironment({ baseEnvironment } = {}) {
         name: this.testPath,
         tags: transactionOptions.tags,
       });
-      this.global._transaction = this.transaction;
+      this.global.transaction = this.transaction;
 
       this.Sentry.configureScope((scope) => scope.setSpan(this.transaction));
 


### PR DESCRIPTION
Test events works for the regular framework functions, but it would be nice to have access to the transaction so we can add temporary spans in test code to help debug slow running transactions inside test runs in CI.