### PR TITLE
fix: Sentry SDK's `setupOnce` w/ `jest --watch`

### DIFF
--- a/createEnvironment.js
+++ b/createEnvironment.js
@@ -16,7 +16,8 @@ function createEnvironment({ baseEnvironment } = {}) {
         !config.testEnvironmentOptions.sentryConfig ||
         // Do not include in watch mode... unfortunately, I don't think there's
         // a better watch to detect when jest is in watch mode
-        process.argv.includes('--watch')
+        process.argv.includes('--watch') ||
+        process.argv.includes('--watchAll')
       ) {
         return;
       }

--- a/createEnvironment.js
+++ b/createEnvironment.js
@@ -13,7 +13,10 @@ function createEnvironment({ baseEnvironment } = {}) {
 
       if (
         !config.testEnvironmentOptions ||
-        !config.testEnvironmentOptions.sentryConfig
+        !config.testEnvironmentOptions.sentryConfig ||
+        // Do not include in watch mode... unfortunately, I don't think there's
+        // a better watch to detect when jest is in watch mode
+        process.argv.includes('--watch')
       ) {
         return;
       }


### PR DESCRIPTION
This was causing problems with jest in watch mode so disable Sentry in watch mode as it is not very useful in that context anyway.